### PR TITLE
Store extended response parameters on GoogleOAuthToken

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Sun May 25 17:47:48 CST 2014
-app.grails.version=2.4.0
+#Fri Sep 09 14:03:22 MDT 2016
+app.grails.version=2.5.4
 app.name=spring-security-oauth-google

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -21,13 +21,7 @@ grails.project.dependency.resolution = {
 
     plugins {
         compile ':spring-security-oauth:2.1.0-RC4'
-
-        // TODO we need this to compile in Grails 2.4...
-        compile ':hibernate:3.6.10.14', {
-            export = false
-        }
-
-        build(':release:3.0.1', ':rest-client-builder:2.0.1') {
+        build(':release:3.0.1', ':rest-client-builder:2.1.1') {
             export = false
         }
     }

--- a/grails-app/services/grails/plugin/springsecurity/oauth/GoogleSpringSecurityOAuthService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauth/GoogleSpringSecurityOAuthService.groovy
@@ -42,7 +42,7 @@ class GoogleSpringSecurityOAuthService {
             log.error "No user email from Google. Response:\n${response.body}"
             throw new OAuthLoginException('No user email from Google')
         }
-        return new GoogleOAuthToken(accessToken, user.email)
+        return new GoogleOAuthToken(accessToken, user.email, user)
     }
 
 }

--- a/src/groovy/grails/plugin/springsecurity/oauth/GoogleOAuthToken.groovy
+++ b/src/groovy/grails/plugin/springsecurity/oauth/GoogleOAuthToken.groovy
@@ -30,11 +30,13 @@ class GoogleOAuthToken extends OAuthToken {
     public static final String PROVIDER_NAME = 'google'
 
     String email
+    Map response
 
-    GoogleOAuthToken(Token scribeToken, email) {
+    GoogleOAuthToken(Token scribeToken, email, response) {
         super(scribeToken)
         this.email = email
         this.principal = email
+        this.response = response
     }
 
     String getSocialId() {


### PR DESCRIPTION
I had the same issue as #3 - when requesting the profile scope, more user information is returned from Google (name, etc). The GoogleSpringSecurityOAuthService discards this information. I changed the service to instead pass the information through on the GoogleOAuthToken as a Map.

Maybe not the best solution, it would be nicer to have a strongly typed response object - but better than nothing for clients that want access to this information.